### PR TITLE
Add followed artists CSV download

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -4,30 +4,40 @@ import { Login } from './Login';
 import { Logout } from './Logout';
 import { PlaylistTable } from './PlaylistTable';
 import { Template } from './Template';
+import { useState } from 'react';
+import { SubtitleDataContext } from './SubtitleDataContext';
 
 export function App() {
   const { matchRoute } = useRouter();
   useLoginRedirect();
 
+  const [subtitleData, setSubtitleData] = useState({ playlistAmount: 0, userId: '' });
+
   if (matchRoute('/spotify_error')) {
     return (
-      <Template>
-        <Error />
-      </Template>
+      <SubtitleDataContext.Provider value={{ viewType: 'error', setSubtitleData, ...subtitleData }}>
+        <Template>
+          <Error />
+        </Template>
+      </SubtitleDataContext.Provider>
     );
   }
 
   if (matchRoute('/playlists')) {
     return (
-      <Template logoutElement={<Logout />}>
-        <PlaylistTable />
-      </Template>
+      <SubtitleDataContext.Provider value={{ viewType: 'playlists', setSubtitleData, ...subtitleData }}>
+        <Template logoutElement={<Logout />}>
+          <PlaylistTable />
+        </Template>
+      </SubtitleDataContext.Provider>
     );
   }
 
   return (
-    <Template>
-      <Login />
-    </Template>
+    <SubtitleDataContext.Provider value={{ viewType: 'login', setSubtitleData, ...subtitleData }}>
+      <Template>
+        <Login />
+      </Template>
+    </SubtitleDataContext.Provider>
   );
 }

--- a/src/components/PlaylistRow.tsx
+++ b/src/components/PlaylistRow.tsx
@@ -77,7 +77,7 @@ export function PlaylistRow({ playlist, index }) {
     setIsExporting(true);
 
     getPlaylistTracks(playlist)
-      .then((tracks) => exportToCsv(tracks, playlist.name))
+      .then((tracks) => exportToCsv(tracks, playlist.name, 'tracks'))
       .finally(() => setIsExporting(false));
   };
 

--- a/src/components/PlaylistTable.tsx
+++ b/src/components/PlaylistTable.tsx
@@ -3,9 +3,12 @@ import { useState, useEffect } from 'react';
 import { getPlaylists, getUser } from 'helpers/data/actions';
 
 import { PlaylistRow } from './PlaylistRow';
+import { useSubtitleDataContext } from './SubtitleDataContext';
 
 export function PlaylistTable() {
   const [playlists, setPlaylists] = useState<any[] | undefined>();
+
+  const { setSubtitleData } = useSubtitleDataContext();
 
   useEffect(() => {
     (async function () {
@@ -13,11 +16,9 @@ export function PlaylistTable() {
       const playlists = await getPlaylists(user.id);
 
       setPlaylists(playlists);
-
-      const subtitleEl = document.getElementById('subtitle');
-      subtitleEl!.textContent = `${playlists.length} playlists for ${user.id}`;
+      setSubtitleData({ playlistAmount: playlists.length, userId: user.id });
     })();
-  }, []);
+  }, [setSubtitleData]);
 
   if (!playlists) return <div className="spinner" />;
 

--- a/src/components/SubtitleDataContext.ts
+++ b/src/components/SubtitleDataContext.ts
@@ -1,0 +1,19 @@
+import { createContext, useContext } from 'react';
+
+export const SubtitleDataContext = createContext<
+  | {
+      viewType: 'error' | 'login' | 'playlists' | null;
+      playlistAmount: number;
+      userId: string;
+      setSubtitleData: (data: { userId: string; playlistAmount: number }) => void;
+    }
+  | undefined
+>(undefined);
+
+SubtitleDataContext.displayName = 'SubtitleDataContext';
+
+export function useSubtitleDataContext() {
+  const data = useContext(SubtitleDataContext);
+
+  return data!;
+}

--- a/src/components/Template.tsx
+++ b/src/components/Template.tsx
@@ -2,6 +2,8 @@ import { ReactNode, ReactElement } from 'react';
 import { ToastContainer } from 'react-toastify';
 
 import { Icon } from './Icon';
+import { useSubtitleDataContext } from './SubtitleDataContext';
+import { exportToCsv, getFollowedArtists } from 'helpers/data/actions';
 
 export function Template({
   children,
@@ -10,6 +12,8 @@ export function Template({
   children: ReactNode;
   logoutElement?: ReactElement | null;
 }) {
+  const { viewType, playlistAmount, userId } = useSubtitleDataContext();
+
   return (
     <div className="App container">
       <header className="App-header">
@@ -22,9 +26,28 @@ export function Template({
           <span>Hatlaron&apos;s Exportify</span>
         </h1>
 
-        <p id="subtitle" className="lead text-secondary">
-          Export and sort your Spotify playlists.
-        </p>
+        {viewType === 'login' ? (
+          <p className="lead text-secondary">Export and sort your Spotify playlists.</p>
+        ) : viewType === 'playlists' && playlistAmount !== 0 ? (
+          <p className="lead text-secondary">
+            {playlistAmount} playlists for {userId}
+            {' ('}
+            <span
+              // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
+              tabIndex={0}
+              className="download-artists"
+              onClick={async () => {
+                const artists = await getFollowedArtists();
+                exportToCsv(artists, 'Followed_artists', 'artist');
+              }}
+            >
+              download followed artists
+            </span>
+            {')'}
+          </p>
+        ) : null}
+
+        <div id="subtitle" />
       </header>
 
       {children}

--- a/src/helpers/data/api.ts
+++ b/src/helpers/data/api.ts
@@ -8,7 +8,7 @@ export function login(clientId: string) {
     clientId +
     '&redirect_uri=' +
     encodeURIComponent([window.location.protocol, '//', window.location.host, window.location.pathname].join('')) +
-    '&scope=playlist-read-private%20playlist-read-collaborative%20user-library-read%20playlist-modify-private%20playlist-modify-public' +
+    '&scope=playlist-read-private%20playlist-read-collaborative%20user-library-read%20playlist-modify-private%20playlist-modify-public%20user-follow-read' +
     '&response_type=token';
 }
 

--- a/src/helpers/data/utils.ts
+++ b/src/helpers/data/utils.ts
@@ -89,6 +89,16 @@ export function convertTracksToCsv(tracks: any[]) {
   return lines.map((line) => line.map(sanitizeLine).join(',') + '\n').join('');
 }
 
+export function convertArtistsToCsv(artists: any[]) {
+  const formattedArtists = artists
+    .map(({ uri, name, id, external_urls }) => [uri, name, id, external_urls.spotify])
+    .sort((a, b) => a[1].localeCompare(b[1]));
+
+  const lines = [['Artist URI', 'Artist Name', 'Artist ID', 'Spotify URL'], ...formattedArtists];
+
+  return lines.map((line) => line.map(sanitizeLine).join(',') + '\n').join('');
+}
+
 export function sanitizeLine(value: string) {
   return '"' + String(value).replace(/"/g, '""') + '"';
 }

--- a/src/index.css
+++ b/src/index.css
@@ -276,3 +276,17 @@ button:disabled {
 #playlists table.table-sm th {
   padding: 8px;
 }
+
+.download-artists {
+  padding: 5px;
+  cursor: pointer;
+  text-decoration: underline;
+  color: white;
+}
+
+.download-artists:hover,
+.download-artists:focus {
+  opacity: 0.8;
+  background-color: black;
+  border-radius: 7.5px;
+}


### PR DESCRIPTION
closes #451 

Add a new button on the top of the playlists page that downloads a CSV of the user's followed artists on spotify

https://github.com/yannickm95/exportify/assets/27205182/0d2a11e6-9476-4810-806d-ef7cd0766dc5


The CSV has the following format: `Artist URI` -> `Artist Name` -> `Artist ID` -> `Spotify Url`